### PR TITLE
Add meta/main.yml to be able to pull from ansible-galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,23 @@
+galaxy_info:
+  role_name: lekane.ansible-cassandra
+
+  issue_tracker_url: https://github.com/lekane/ansible-cassandra/issues
+
+  license: BSD 3-Clause
+
+  min_ansible_version: 2.0
+
+  platforms:
+  - name: Ubuntu
+    versions:
+    - all
+
+  galaxy_tags:
+    - cassandra
+    - datastax-enterprise
+    - datastax-community
+    - dse
+    - dce
+    - apache cassandra
+
+dependencies: []


### PR DESCRIPTION
I created this simple meta/main.yml to be able to run `ansible-galaxy install github.com/lekane/ansible-cassandra` Closes #9 